### PR TITLE
Performance improvement: avoid calling pg::relative_path unless _PGEM_DEBUG is set

### DIFF
--- a/private.sh
+++ b/private.sh
@@ -148,7 +148,8 @@ pg::_gh_migrate() {
 # Sources a file if it exists, skips if not
 pg::_srcIfExist() {
   if [[ -f "${1:?}" ]];  then
-    pg::log "Including $(pg::relative_path "$1" "$_PGEM_LOC")"
+    # pg::relative_path is slow, so we need to guard this call
+    if "${_PGEM_DEBUG:-false}"; then pg::log "Including $(pg::relative_path "$1" "$_PGEM_LOC")"; fi;
     source "$1"
   fi
 }


### PR DESCRIPTION
I love one-line perf improvements!

This one is caused by the `pg::relative_path` function which invokes python and adds ~10ms of latency. In `private.sh`, `pg::_srcIfExist` is used by all initilization calls and includes a call to `pg::relative_path` for debug logs. The fix is to simply not execute the log call if we're not in debug mode.

### Before

```bash
$ time (for i in {1..500}; do source load.sh ; done)

real    2m16.374s
user    1m51.982s
sys     0m33.549s
```

### After

```bash
$ time (for i in {1..500}; do source load.sh ; done)

real    0m30.740s
user    0m27.950s
sys     0m8.884s
```